### PR TITLE
Solved Djongo SQLDecodeError

### DIFF
--- a/insertions_service/insertions_manager/migrations/0009_box.py
+++ b/insertions_service/insertions_manager/migrations/0009_box.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('weight', models.DecimalField(decimal_places=3, default=0.0, max_digits=6, validators=[django.core.validators.MinValueValidator(0)])),
                 ('size', models.IntegerField()),
-                ('price', models.IntegerField()),
+                ('price', models.DecimalField(decimal_places=2, default=0.0, max_digits=5)),
                 ('insertion', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='insertions_manager.insertion')),
             ],
         ),


### PR DESCRIPTION
@Marco7years noted an error with the migration `0012_box_number_of_available_boxes_alter_box_price_and_more.py` while migrating the db.
Changing the migration `0009_box.py` solved the issue. It seems like Djongo has some problem altering an attribute field from one type to another (in this case from IntegerField to DecimalField). This solution probably applies also to #8.
This pull request closes the issue #7.